### PR TITLE
Implement API-based lap data fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To launch the Flask webapp locally:
 python -m laptimeanalyzer.webapp
 ```
 
-This will start a development server on <http://localhost:5000> where you can upload lap time CSV files and explore interactive graphs.
+This will start a development server on <http://localhost:5000> where you can select a season and circuit to fetch lap times from the Ergast API and explore interactive graphs.
 
 ## Deployment Notes
 

--- a/laptimeanalyzer/data.py
+++ b/laptimeanalyzer/data.py
@@ -1,4 +1,17 @@
 import pandas as pd
+import requests
+
+
+def _time_to_seconds(t):
+    """Convert a lap time string like '1:39.019' to seconds."""
+    if not isinstance(t, str):
+        return float('nan')
+    parts = t.split(":")
+    if len(parts) == 2:
+        minutes, sec = parts
+    else:
+        minutes, sec = 0, parts[0]
+    return int(minutes) * 60 + float(sec)
 
 
 def load_lap_times(file_obj):
@@ -11,4 +24,56 @@ def compute_deltas(df, time_col="lap_time"):
     fastest = df[time_col].min()
     df = df.copy()
     df["delta"] = df[time_col] - fastest
+    return df
+
+
+def fetch_circuits(year):
+    """Return a list of (round, circuit name) tuples for a given year."""
+    url = f"https://ergast.com/api/f1/{year}.json"
+    res = requests.get(url, timeout=10)
+    races = res.json().get("MRData", {}).get("RaceTable", {}).get("Races", [])
+    return [(r["round"], r["Circuit"]["circuitName"]) for r in races]
+
+
+def fetch_lap_times(year, round_num):
+    """Fetch lap times for a given year and race round from the Ergast API."""
+    base = "https://ergast.com/api/f1"
+    lap_url = f"{base}/{year}/{round_num}/laps.json?limit=2000"
+    lap_res = requests.get(lap_url, timeout=10)
+    races = lap_res.json().get("MRData", {}).get("RaceTable", {}).get("Races", [])
+    if not races:
+        return pd.DataFrame()
+    laps = races[0].get("Laps", [])
+
+    rows = []
+    for lap in laps:
+        num = int(lap["number"])
+        for t in lap.get("Timings", []):
+            rows.append(
+                {
+                    "lap": num,
+                    "driverId": t["driverId"],
+                    "lap_time": _time_to_seconds(t["time"]),
+                }
+            )
+
+    res_url = f"{base}/{year}/{round_num}/results.json"
+    results_json = requests.get(res_url, timeout=10).json()
+    race = results_json.get("MRData", {}).get("RaceTable", {}).get("Races", [])[0]
+    results = race.get("Results", [])
+    circuit_name = race.get("Circuit", {}).get("circuitName")
+
+    driver_map = {
+        r["Driver"]["driverId"]: {
+            "driver": f"{r['Driver']['givenName']} {r['Driver']['familyName']}",
+            "team": r["Constructor"]["name"],
+        }
+        for r in results
+    }
+
+    df = pd.DataFrame(rows)
+    df["driver"] = df["driverId"].map(lambda d: driver_map.get(d, {}).get("driver"))
+    df["team"] = df["driverId"].map(lambda d: driver_map.get(d, {}).get("team"))
+    df["track"] = circuit_name
+    df.drop(columns=["driverId"], inplace=True)
     return df

--- a/laptimeanalyzer/templates/dashboard.html
+++ b/laptimeanalyzer/templates/dashboard.html
@@ -5,6 +5,7 @@
 </head>
 <body>
     <h1>Lap Time Dashboard</h1>
+    <p>Year: {{ year }}, Circuit: {{ circuit_name }}</p>
     <form method="get">
         Driver:
         <select name="driver">

--- a/laptimeanalyzer/templates/index.html
+++ b/laptimeanalyzer/templates/index.html
@@ -1,13 +1,26 @@
 <!doctype html>
 <html>
 <head>
-    <title>Lap Time Analyzer - Upload</title>
+    <title>Lap Time Analyzer - Select Race</title>
 </head>
 <body>
-    <h1>Upload Lap Times CSV</h1>
-    <form method="post" enctype="multipart/form-data">
-        <input type="file" name="file" required>
-        <input type="submit" value="Upload">
+    <h1>Select Race</h1>
+    <form method="post">
+        Year:
+        <select name="year" onchange="this.form.submit()">
+            <option value="">-- Select Year --</option>
+            {% for y in years %}
+            <option value="{{ y }}" {% if y|string == selected_year %}selected{% endif %}>{{ y }}</option>
+            {% endfor %}
+        </select>
+        <br/>
+        Circuit:
+        <select name="circuit">
+            {% for r, name in circuits %}
+            <option value="{{ r }}" {% if r == selected_circuit %}selected{% endif %}>{{ name }}</option>
+            {% endfor %}
+        </select>
+        <input type="submit" value="Load">
     </form>
 </body>
 </html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask
 plotly
 pandas
+requests


### PR DESCRIPTION
## Summary
- remove CSV upload flow and add year/circuit selection
- use Ergast API to fetch lap data and circuit lists
- show selected year and circuit on dashboard
- document running new flow in README
- add `requests` to requirements

## Testing
- `python -m py_compile laptimeanalyzer/*.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683ff0dc3504832284b0370b11852bc2